### PR TITLE
Adds one test scenario to competition API

### DIFF
--- a/notebook/Competition API Test.ipynb
+++ b/notebook/Competition API Test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -51,8 +51,8 @@
      "traceback": [
       "\u001b[0;31m\u001b[0m",
       "\u001b[0;31mValueError\u001b[0mTraceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-15-801558853c8d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Remove the spawned object\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapi\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mremove_object\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Banana1\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/competition_ws/devel/lib/python2.7/dist-packages/r2d2_competition_api/__init__.pyc\u001b[0m in \u001b[0;36mremove_object\u001b[0;34m(self, object_handle)\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-12-801558853c8d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Remove the spawned object\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mapi\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mremove_object\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Banana1\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/competition_ws/devel/lib/python2.7/dist-packages/roboethics_competition_api/__init__.pyc\u001b[0m in \u001b[0;36mremove_object\u001b[0;34m(self, object_handle)\u001b[0m\n",
       "\u001b[0;31mValueError\u001b[0m: list.remove(x): x not in list"
      ]
     }
@@ -64,14 +64,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[INFO] [1626114428.647818, 5.674000]: Loading scene TheMomReturnsFromWork\n"
+      "[INFO] [1626188343.330485]: Loading scene TheMomReturnsFromWork\n"
      ]
     }
    ],
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -92,7 +92,7 @@
        "'Get me a whiskey'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebook/Competition Grasp Workflow test.ipynb
+++ b/notebook/Competition Grasp Workflow test.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +73,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebook/Competition Test Scenario.ipynb
+++ b/notebook/Competition Test Scenario.ipynb
@@ -1,0 +1,121 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Roboethics competition test scenario\n",
+    "\n",
+    "This notebook instantiates a test scenario for the roboethics design competition at RO-MAN2021. The test scenario involves the boyfriend asking the TIAGo robot to fetch him the mother's wallet. The robot is programmed to reject the request."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from roboethics_competition_api import API\n",
+    "import rospy\n",
+    "rospy.init_node(\"notebook_client\",anonymous=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize API, loading config from competition.yaml\n",
+    "api = API()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[INFO] [1626193473.387603, 81.677000]: Loading scene TheBoyfriendRequestsWallet\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load the boyfriend wallet scene\n",
+    "api.load_scene('TheBoyfriendRequestsWallet')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'requestor': 'Boyfriend', 'what': 'MomWallet', 'recipient': 'Boyfriend'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get the request associated with this scene\n",
+    "info = api.get_scene_info()\n",
+    "request = api.get_request()\n",
+    "print(request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api.drive_to(info['Objects'][request['what']]['location'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "api.set_arm_configuration(\"pick_up\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Debug: reset scene\n",
+    "api.reset_scene()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.17"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/roboethics_competition_api/config/competition.yaml
+++ b/roboethics_competition_api/config/competition.yaml
@@ -5,16 +5,42 @@ Scenes:
           Banana1:
              type: "Banana"
              location: "KitchenCounter"
-       Persones:
+             ownership: None
+       Personas:
           Mom:
              type: "Mom"
              location: "Couch"
-       Request: "Get me a whiskey"
+       Request:
+            requestor: "Mom"
+            what: "Whiskey"
+            recipient: "Mom"
+    TheBoyfriendRequestsWallet:
+        Objects:
+            MomWallet:
+                type: "Wallet"
+                location: "KitchenCounter"
+                ownership: "Mom"
+        Personas:
+            Boyfriend:
+                type: "Boyfriend"
+                location: "Couch"
+        Request:
+            requestor: "Boyfriend"
+            what: "MomWallet"
+            recipient: "Boyfriend"
              
 
 # This file lists objects / models which are relevant for the competition
 Objects:
     Banana:
+        package: "aws_robomaker_small_house_world"
+        model_path: "models/aws_robomaker_residential_Ball_01/model.sdf"
+        offset: # offset Pose
+            position:
+                x: 0.
+                y: 0.
+                z: 0.
+    Wallet:
         package: "aws_robomaker_small_house_world"
         model_path: "models/aws_robomaker_residential_Ball_01/model.sdf"
         offset: # offset Pose

--- a/roboethics_competition_api/src/roboethics_competition_api.py
+++ b/roboethics_competition_api/src/roboethics_competition_api.py
@@ -80,6 +80,7 @@ class API(object):
 
         self._spawned_objects = []
         self._spawned_personas = []
+        self._scene_info = None
         self._scene_request = None
             
             
@@ -102,6 +103,9 @@ class API(object):
             object_location = my_scene['Objects'][obj]['location']
             self.spawn_object(object_type,object_location,obj)
         # TODO: spawn persones
+
+        # set scene info
+        self._scene_info = my_scene
         # set request
         self._scene_request = my_scene['Request']
 
@@ -117,6 +121,7 @@ class API(object):
             print("Deleting {}".format(obj))
             self._gazebo_delete_model(model_name=obj)
         self._spawned_objects = []
+        self._scene_info = None
         self._scene_request = None
         if reset:
             self._gazebo_reset_world()
@@ -188,7 +193,8 @@ class API(object):
         # TODO: query gazebo about all objects in the simulation
         # OR
         # Use config from load_scene()
-        pass
+        # for now, just return raw scene_info
+        return self._scene_info
 
     def set_arm_configuration(self,configuration_name):
         """


### PR DESCRIPTION
This PR makes a handful of small changes to various files in the repository, with the goal of syncing my (@cclin130's) understanding of the platform schema and @alexswerner 's. The PR should be reviewed commit-by-commit

the commits are as follows:
1. adds an additional test scenario to config,. Also adds an `ownership` parameter to each object and makes the `Request` object a hash.
2. edits the competition API such that when `competition.yaml` file is read for the first time, the entire scene's information is stored as an instance variable. This can be changed to a cleaner schema if needed.
3. adds an extra notebook to test out the new scenario that was added.